### PR TITLE
Bumps q2-metabolomics to python 3.6

### DIFF
--- a/build_conda.sh
+++ b/build_conda.sh
@@ -6,4 +6,4 @@ conda-build . \
  -c https://conda.anaconda.org/bioconda \
  -c https://conda.anaconda.org/biocore \
  --override-channels \
- --python 3.5
+ --python 3.6

--- a/meta.yaml
+++ b/meta.yaml
@@ -7,14 +7,14 @@ source:
 
 requirements:
   build:
-    - python 3.5*
+    - python 3.6*
     - setuptools
 
 build:
   noarch: generic
 
 run:
-  - python 3.5*
+  - python 3.6*
   - setuptools
   - pandas
   - ftputil


### PR DESCRIPTION
Hey there, @mwang87 !
It looks like the failure to `conda install` mentioned on the recent QIIME 2 [forum post](https://forum.qiime2.org/t/cant-find-q2-metabolomics-plugin/12946/5) and in #51 may have been caused by an out-of-date python version. QIIME 2 moved to python 3.6 in v. 2019.1, and `q2-metabolomics` was pinned to Python 3.5. 

I have successfully [built](https://anaconda.org/ChrisKeefe/q2-metabolomics) and installed `q2-metabolomics` from this source on linuxmint 19.2, but it's worth testing prior to merge. 

Let me know if you have any questions. Hope this helps!
Chris